### PR TITLE
Ditch Profile

### DIFF
--- a/routes/login/login.go
+++ b/routes/login/login.go
@@ -18,7 +18,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 		ClientID:     os.Getenv("AUTH0_CLIENT_ID"),
 		ClientSecret: os.Getenv("AUTH0_CLIENT_SECRET"),
 		RedirectURL:  os.Getenv("AUTH0_CALLBACK_URL"),
-		Scopes:       []string{"openid", "profile", "offline_access"},
+		Scopes:       []string{"openid", "offline_access"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  "https://" + domain + "/authorize",
 			TokenURL: "https://" + domain + "/oauth/token",


### PR DESCRIPTION
Somehow my profile has grown somewhat and this causes the callback to
fail due the cookie exceeding the maximum size of about 4k.

The profile is not really needed for this use case, so I am excluding it
from the request during login.